### PR TITLE
defer is not needed for small functions

### DIFF
--- a/item.go
+++ b/item.go
@@ -41,12 +41,12 @@ func NewMaceItem(key string, val interface{}, aliveUntil time.Duration) *MaceIte
 
 func (item *MaceItem) KeepAlive() {
 	item.Lock()
-	defer item.Unlock()
 	item.access = time.Now()
 	item.accessCount++
 	if item.alive != 0 {
 		item.dispose.disposeTime = item.access.Add(item.alive)
 	}
+	item.Unlock()
 	return
 }
 
@@ -64,8 +64,9 @@ func (item *MaceItem) Data() interface{} {
 
 func (item *MaceItem) AccessCount() int {
 	item.RLock()
-	defer item.RUnlock()
-	return item.accessCount
+	r := item.accessCount
+	item.RUnlock()
+	return r
 }
 
 func (item *MaceItem) Created() time.Time {
@@ -74,6 +75,7 @@ func (item *MaceItem) Created() time.Time {
 
 func (item *MaceItem) Access() time.Time {
 	item.RLock()
-	defer item.RUnlock()
-	return item.access
+	r := item.access
+	item.RUnlock()
+	return r
 }


### PR DESCRIPTION
Here's some a small profile test when using defer vs without it.

with defer:

```
$ go tool pprof macetest /tmp/profile255001396/cpu.pprof
Entering interactive mode (type "help" for commands)
(pprof) top 10
86.79s of 99.71s total (87.04%)
Dropped 2 nodes (cum <= 0.50s)
Showing top 10 nodes out of 24 (cum >= 11.22s)
      flat  flat%   sum%        cum   cum%
    14.70s 14.74% 14.74%     14.70s 14.74%  sync/atomic.AddUint32
    13.70s 13.74% 28.48%     29.96s 30.05%  runtime.deferreturn
    12.36s 12.40% 40.88%     12.36s 12.40%  runtime.newdefer
    12.01s 12.04% 52.92%     12.01s 12.04%  runtime.freedefer
     8.82s  8.85% 61.77%     40.44s 40.56%  runtime.systemstack
     7.57s  7.59% 69.36%        84s 84.24%  github.com/ruizu/macetest/vendor/github.com/djinn/mace.(*MaceBucket).Count
     4.82s  4.83% 74.20%     24.47s 24.54%  runtime.deferproc
     4.79s  4.80% 79.00%     88.79s 89.05%  main.main
     4.41s  4.42% 83.42%     18.05s 18.10%  runtime.deferproc.func1
     3.61s  3.62% 87.04%     11.22s 11.25%  sync.(*RWMutex).RUnlock
```

without defer:

```
$ go tool pprof macetest /tmp/profile742982144/cpu.pprof
Entering interactive mode (type "help" for commands)
(pprof) top10
21.54s of 21.54s total (  100%)
Showing top 10 nodes out of 14 (cum >= 21.09s)
      flat  flat%   sum%        cum   cum%
    13.12s 60.91% 60.91%     13.12s 60.91%  sync/atomic.AddUint32
     2.40s 11.14% 72.05%     20.52s 95.26%  github.com/ruizu/macetest/vendor/github.com/djinn/mace.(*MaceBucket).Count
     2.21s 10.26% 82.31%      9.09s 42.20%  sync.(*RWMutex).RLock
     2.18s 10.12% 92.43%      9.03s 41.92%  sync.(*RWMutex).RUnlock
     0.61s  2.83% 95.26%      0.61s  2.83%  sync/atomic.AddInt32
     0.57s  2.65% 97.91%     21.09s 97.91%  main.main
     0.24s  1.11% 99.03%      0.24s  1.11%  runtime.usleep
     0.21s  0.97%   100%      0.21s  0.97%  runtime._ExternalCode
         0     0%   100%      0.21s  0.97%  runtime._System
         0     0%   100%     21.09s 97.91%  runtime.goexit
```
